### PR TITLE
fix: resolve clippy collapsible_match warnings

### DIFF
--- a/src/executor/compress.rs
+++ b/src/executor/compress.rs
@@ -167,16 +167,10 @@ fn compress_rar(
         command.current_dir(directory.path().to_string_lossy().to_string());
 
         match command.execute() {
-            Ok(Some(exit_code)) => {
-                if exit_code == 0 {
-                    let mut success_files = success_files.lock().unwrap();
-                    success_files.insert(output_filename.to_string(), false);
-                    bar.set_message(format!("Compressed {}!", &output_filename));
-                } else {
-                    let mut error_files = error_files.lock().unwrap();
-                    error_files.push(output_filename.to_string());
-                    bar.set_message(format!("Failed to compress {}!", &output_filename));
-                }
+            Ok(Some(0)) => {
+                let mut success_files = success_files.lock().unwrap();
+                success_files.insert(output_filename.to_string(), false);
+                bar.set_message(format!("Compressed {}!", &output_filename));
             }
             _ => {
                 let mut error_files = error_files.lock().unwrap();
@@ -418,14 +412,9 @@ fn validate_rar(
         bar.set_message(format!("Validating {filename}"));
 
         let is_valid = match command.execute() {
-            Ok(Some(exit_code)) => {
-                if exit_code == 0 {
-                    bar.set_message("OK");
-                    true
-                } else {
-                    bar.set_message("NG");
-                    false
-                }
+            Ok(Some(0)) => {
+                bar.set_message("OK");
+                true
             }
             _ => {
                 bar.set_message("NG");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- CI の `cargo clippy -- -D warnings` で失敗していた `clippy::collapsible_match` を修正
- `src/executor/compress.rs` のネストした `if exit_code == 0` を `Ok(Some(0))` の match arm にまとめ、失敗時は既存の `_` arm に集約

## Test plan
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c3b7e7b-bc69-4801-a793-66fbf76f0f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c3b7e7b-bc69-4801-a793-66fbf76f0f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

